### PR TITLE
Overrided GET /mcp to return 405 to avoid opening a long living stream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "jq>=1.10.0",
     "typer>=0.20.0",
     "pydantic-settings>=2.12.0",
+    "fastapi>=0.136.0",
+    "starlette>=0.50.0",
 ]
 
 [project.scripts]

--- a/src/open_targets_platform_mcp/cli.py
+++ b/src/open_targets_platform_mcp/cli.py
@@ -1,8 +1,13 @@
 import asyncio
 from importlib import metadata
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 
 from open_targets_platform_mcp.create_server import create_server
 from open_targets_platform_mcp.settings import TransportType, settings
@@ -151,12 +156,26 @@ def root(
 
     try:
         if settings.transport == TransportType.HTTP:
-            mcp.run(
+
+            class MCPMethodOverrideMiddleware(BaseHTTPMiddleware):
+                async def dispatch(self, request: Request, call_next: Any) -> JSONResponse:
+                    if request.url.path in {"/mcp", "/mcp/"} and request.method in {"GET", "HEAD", "OPTIONS"}:
+                        return JSONResponse(
+                            status_code=405,
+                            content={"error": "Method Not Allowed"},
+                            headers={"Allow": "POST"},
+                        )
+                    return await call_next(request)
+
+            mcp_asgi = mcp.http_app(
+                path="/",
                 transport=settings.transport.value,
-                host=settings.http_host,
-                port=settings.http_port,
                 stateless_http=settings.stateless_http,
             )
+            app = FastAPI(lifespan=mcp_asgi.lifespan)
+            app.mount("/mcp", mcp_asgi)
+            app.add_middleware(MCPMethodOverrideMiddleware)
+            uvicorn.run(app, host=settings.http_host, port=settings.http_port)
         else:
             mcp.run(
                 transport=settings.transport.value,

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +497,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
 ]
 
 [[package]]
@@ -948,14 +973,16 @@ wheels = [
 
 [[package]]
 name = "open-targets-platform-mcp"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "fastmcp" },
     { name = "gql", extra = ["aiohttp"] },
     { name = "jq" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "starlette" },
     { name = "typer" },
 ]
 
@@ -968,11 +995,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.136.0" },
     { name = "fastmcp", specifier = ">=2.13.0.2" },
     { name = "gql", extras = ["aiohttp"], specifier = ">=4.0.0" },
     { name = "jq", specifier = ">=1.10.0" },
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "starlette", specifier = ">=0.50.0" },
     { name = "typer", specifier = ">=0.20.0" },
 ]
 


### PR DESCRIPTION
Testing the method to fix a bug on FastMCP 2.X that `GET /mcp` still opens a stream even with stateless http mode.

https://github.com/PrefectHQ/fastmcp/issues/3179