### PR TITLE
Always pass explicit tool descriptions to bypass FastMCP 3.x docstring truncation

### DIFF
--- a/src/open_targets_platform_mcp/create_server.py
+++ b/src/open_targets_platform_mcp/create_server.py
@@ -102,7 +102,13 @@ async def create_server() -> FastMCP:
         description=build_schema_docstring(),
         annotations={"readOnlyHint": True},
     )
-    mcp.tool(get_type_dependencies, annotations={"readOnlyHint": True})
+    mcp.tool(
+        get_type_dependencies,
+        description=resources.files("open_targets_platform_mcp.tools.schema")
+        .joinpath("type_graph_description.txt")
+        .read_text(encoding="utf-8"),
+        annotations={"readOnlyHint": True},
+    )
     mcp.tool(
         search_entities,
         description=resources.files("open_targets_platform_mcp.tools.search_entities")

--- a/src/open_targets_platform_mcp/create_server.py
+++ b/src/open_targets_platform_mcp/create_server.py
@@ -20,6 +20,7 @@ from open_targets_platform_mcp.tools import (
     query_without_jq,
     search_entities,
 )
+from open_targets_platform_mcp.tools.schema.schema import build_schema_docstring
 
 
 async def create_server() -> FastMCP:
@@ -96,7 +97,11 @@ async def create_server() -> FastMCP:
     async def health_check(_: Request) -> JSONResponse:
         return JSONResponse({"status": "healthy", "service": "mcp-server"})
 
-    mcp.tool(get_open_targets_graphql_schema, annotations={"readOnlyHint": True})
+    mcp.tool(
+        get_open_targets_graphql_schema,
+        description=build_schema_docstring(),
+        annotations={"readOnlyHint": True},
+    )
     mcp.tool(get_type_dependencies, annotations={"readOnlyHint": True})
     mcp.tool(
         search_entities,

--- a/src/open_targets_platform_mcp/tools/schema/type_graph.py
+++ b/src/open_targets_platform_mcp/tools/schema/type_graph.py
@@ -29,27 +29,13 @@ async def get_type_dependencies(
         ),
     ],
 ) -> dict[str, str]:
-    """Get schema subsets for types, separated by specific and shared deps.
+    """Get SDL subsets for the given GraphQL type names, split into
+    type-specific and shared dependencies.
 
-    Given a list of type names, returns SDL (Schema Definition Language)
-    organized into type-specific dependencies and shared dependencies.
-
-    Returns a dict with:
-        - One key per input type: SDL for types ONLY reachable from that type
-        - "shared" key: SDL for types reachable from multiple input types
-
-    Examples:
-        - get_type_dependencies(["Target"]) - All deps under "Target" key
-        - get_type_dependencies(["Target", "Drug"]) - Separated + shared
-
-    Args:
-        type_names: List of GraphQL type names to start exploration from
-
-    Returns:
-        dict with type-specific SDL and shared SDL
-
-    Raises:
-        ValueError: If any type_name is not found in the schema
+    The model-facing description lives in `type_graph_description.txt` and is
+    passed explicitly to `mcp.tool(...)` in `create_server.py` to bypass
+    FastMCP 3.x's griffe docstring parser, which truncates Google-style
+    sections.
     """
     graph = await type_graph_cache.get()
     available_types = sorted(graph.types.keys())

--- a/src/open_targets_platform_mcp/tools/schema/type_graph.py
+++ b/src/open_targets_platform_mcp/tools/schema/type_graph.py
@@ -33,9 +33,7 @@ async def get_type_dependencies(
     type-specific and shared dependencies.
 
     The model-facing description lives in `type_graph_description.txt` and is
-    passed explicitly to `mcp.tool(...)` in `create_server.py` to bypass
-    FastMCP 3.x's griffe docstring parser, which truncates Google-style
-    sections.
+    passed explicitly to `mcp.tool(...)` in `create_server.py`.
     """
     graph = await type_graph_cache.get()
     available_types = sorted(graph.types.keys())

--- a/src/open_targets_platform_mcp/tools/schema/type_graph_description.txt
+++ b/src/open_targets_platform_mcp/tools/schema/type_graph_description.txt
@@ -1,0 +1,21 @@
+Get schema subsets for types, separated by specific and shared deps.
+
+Given a list of type names, returns SDL (Schema Definition Language)
+organized into type-specific dependencies and shared dependencies.
+
+Returns a dict with:
+    - One key per input type: SDL for types ONLY reachable from that type
+    - "shared" key: SDL for types reachable from multiple input types
+
+Examples:
+    - get_type_dependencies(["Target"]) - All deps under "Target" key
+    - get_type_dependencies(["Target", "Drug"]) - Separated + shared
+
+Args:
+    type_names: List of GraphQL type names to start exploration from
+
+Returns:
+    dict with type-specific SDL and shared SDL
+
+Raises:
+    ValueError: If any type_name is not found in the schema

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -47,6 +47,19 @@ class TestCreateServer:
         assert "genetic-associations" in tool.description
 
     @pytest.mark.asyncio
+    async def test_type_dependencies_tool_description_is_full(self):
+        """The registered get_type_dependencies description must include the
+        Examples block and the dict-shape explanation, regardless of FastMCP
+        version. Same griffe-truncation regression as above."""
+        server = await create_server()
+        tool = await server.get_tool("get_type_dependencies")
+
+        assert tool.description is not None
+        assert "Examples:" in tool.description
+        assert 'get_type_dependencies(["Target"])' in tool.description
+        assert "shared" in tool.description
+
+    @pytest.mark.asyncio
     async def test_all_tools_have_readonly_hint(self):
         """Test that all registered tools have readOnlyHint set to True."""
         server = await create_server()

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -4,6 +4,7 @@ import pytest
 
 from open_targets_platform_mcp.create_server import create_server
 from open_targets_platform_mcp.server import mcp
+from open_targets_platform_mcp.tools.schema.schema import build_schema_docstring
 
 
 class TestCreateServer:
@@ -26,6 +27,24 @@ class TestCreateServer:
         result = await create_server()
 
         assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_schema_tool_description_is_full_docstring(self):
+        """The registered get_open_targets_graphql_schema description must include
+        the full category list, regardless of FastMCP version.
+
+        Regression: FastMCP 3.x parses Google-style docstrings via griffe and only
+        keeps the first text section, dropping the trailing "Available categories:"
+        block. Passing description= explicitly to mcp.tool(...) bypasses that.
+        """
+        server = await create_server()
+        tool = await server.get_tool("get_open_targets_graphql_schema")
+
+        assert tool.description is not None
+        assert tool.description.rstrip() == build_schema_docstring().rstrip()
+        assert "Available categories:" in tool.description
+        assert "drug-mechanisms" in tool.description
+        assert "genetic-associations" in tool.description
 
     @pytest.mark.asyncio
     async def test_all_tools_have_readonly_hint(self):

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -49,24 +49,28 @@ class TestCreateServer:
     @pytest.mark.asyncio
     async def test_all_tools_have_readonly_hint(self):
         """Test that all registered tools have readOnlyHint set to True."""
-        server = create_server()
-        tools = await server.get_tools()
+        server = await create_server()
 
-        # Ensure at least one tool is registered
+        # FastMCP 2.x exposes get_tools() returning a dict; 3.x exposes list_tools()
+        # returning a list.
+        if hasattr(server, "get_tools"):
+            tools = list((await server.get_tools()).values())
+        else:
+            tools = await server.list_tools()
+
         assert len(tools) > 0, "No tools registered in the server"
 
-        # Check each tool has readOnlyHint=True
-        for tool_name, tool_obj in tools.items():
-            assert hasattr(tool_obj, "annotations"), f"Tool '{tool_name}' has no annotations attribute"
+        for tool_obj in tools:
+            assert hasattr(tool_obj, "annotations"), f"Tool '{tool_obj.name}' has no annotations attribute"
 
             annotations = tool_obj.annotations
             assert hasattr(
                 annotations,
                 "readOnlyHint",
-            ), f"Tool '{tool_name}' annotations have no readOnlyHint attribute"
+            ), f"Tool '{tool_obj.name}' annotations have no readOnlyHint attribute"
 
             assert annotations.readOnlyHint is True, (
-                f"Tool '{tool_name}' does not have readOnlyHint=True (got {annotations.readOnlyHint})"
+                f"Tool '{tool_obj.name}' does not have readOnlyHint=True (got {annotations.readOnlyHint})"
             )
 
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -31,11 +31,11 @@ class TestCreateServer:
     @pytest.mark.asyncio
     async def test_schema_tool_description_is_full_docstring(self):
         """The registered get_open_targets_graphql_schema description must include
-        the full category list, regardless of FastMCP version.
+        the full category list.
 
-        Regression: FastMCP 3.x parses Google-style docstrings via griffe and only
-        keeps the first text section, dropping the trailing "Available categories:"
-        block. Passing description= explicitly to mcp.tool(...) bypasses that.
+        Regression: FastMCP parses Google-style docstrings and only keeps the
+        first text section, dropping the trailing "Available categories:" block.
+        Passing description= explicitly to mcp.tool(...) preserves it.
         """
         server = await create_server()
         tool = await server.get_tool("get_open_targets_graphql_schema")
@@ -49,8 +49,8 @@ class TestCreateServer:
     @pytest.mark.asyncio
     async def test_type_dependencies_tool_description_is_full(self):
         """The registered get_type_dependencies description must include the
-        Examples block and the dict-shape explanation, regardless of FastMCP
-        version. Same griffe-truncation regression as above."""
+        Examples block and the dict-shape explanation. Same docstring-parser
+        regression as above."""
         server = await create_server()
         tool = await server.get_tool("get_type_dependencies")
 
@@ -64,7 +64,7 @@ class TestCreateServer:
         """Test that all registered tools have readOnlyHint set to True."""
         server = await create_server()
 
-        # FastMCP 2.x exposes get_tools() returning a dict; 3.x exposes list_tools()
+        # FastMCP exposes either get_tools() returning a dict or list_tools()
         # returning a list.
         if hasattr(server, "get_tools"):
             tools = list((await server.get_tools()).values())


### PR DESCRIPTION
## Context

Two sibling benchmark runs executed the same model against the same benchmark, differing only in how the OTP MCP server was launched:

- **local**: `uv run --directory <local checkout> otp-mcp` with the pinned `fastmcp==2.13.3` from the lockfile.
- **uvx**: `uvx --from git+https://github.com/opentargets/open-targets-platform-mcp otp-mcp`, which resolves `fastmcp>=2.13.0.2` to the latest 3.x (3.2.4 at time of writing).

The two runs produced very different tool-error profiles, which triggered this investigation.

## Symptom

In the uvx run, the second tool call in nearly every trajectory is `get_open_targets_graphql_schema` and it fails on the very first attempt with hallucinated category names (`protein-protein-interactions`, `target`, `clinical-trials`, `drug`, `disease`, `pathway`, `targets`). The local run never produces these failures and only ever sends valid category names (`genetic-associations`, `variant-annotation`, `drug-mechanisms`, `functional-genomics`, etc.).

Evidence from server logs:

- uvx log: **1088** "Invalid category name(s)" errors.
- local log: **0** such errors.

Evidence from call distributions:

- uvx: 346 schema calls; top categories all hallucinated (`target` 52x, `clinical-trials` 13x, `pathway` 8x, `drug` 7x, `disease` 7x, `targets` 7x).
- local: 145 schema calls; top categories all valid (`genetic-associations` 16x, `variant-annotation` 10x, `functional-genomics` 9x, `drug-mechanisms` 9x).

## Root cause

FastMCP 2.x uses `inspect.getdoc()` to extract the tool description, returning the full docstring. FastMCP 3.x introduces `fastmcp/utilities/docstring_parsing.py`, which uses `griffe` to parse Google / NumPy / Sphinx-style docstrings and only keeps the first `DocstringSectionKind.text` section — anything after the first `Args:` / `Returns:` / `Examples:` block is silently dropped.

Two of the five registered tools were affected because they relied on the function's `__doc__` (via auto-extraction):

- `get_open_targets_graphql_schema`: description truncated from ~5360 chars to ~384 chars, dropping the entire "Available categories:" block. The model only saw the three example categories in the leading paragraph (`drug-mechanisms`, `genetic-associations`, `target-safety`) and hallucinated names for anything else.
- `get_type_dependencies`: description truncated from ~723 chars to ~205 chars, dropping the `Examples:` block and the explanation of the returned dict shape (`shared` key, etc.).

The other three tools (`search_entities`, `query_open_targets_graphql`, `batch_query_open_targets_graphql`) were already passing `description=...read_text(...)` explicitly, so they were unaffected.

## Summary

- For consistency, all tool registrations now pass `description=` explicitly. After this change there is zero reliance on FastMCP's docstring auto-extraction.
- `get_open_targets_graphql_schema`: registered with `description=build_schema_docstring()` (the same builder that previously fed `__doc__`).
- `get_type_dependencies`: docstring extracted into a new `tools/schema/type_graph_description.txt`; function `__doc__` shortened to a one-line developer summary; registration now reads the .txt and passes it as `description=`. This matches the pattern already used by `search_entities`, `query`, and `batch_query`.
- New regression tests assert each registered tool description still contains its critical content (category list for the schema tool; `Examples:` block and `shared` explanation for the type-dependencies tool).
- Drive-by fix to `test_all_tools_have_readonly_hint`, which was already broken on `main` (missing `await create_server()` and used `get_tools()` plural which doesn't exist on FastMCP 3.x). Now uses a `hasattr` fallback to support both 2.x and 3.x.

## Test plan

- [x] `pytest` passes (109/109) on `fastmcp==2.13.3`
- [x] `pytest` passes (109/109) on `fastmcp==3.2.4`
- [x] Each new regression test fails on FastMCP 3.x without its corresponding fix and passes with it (verified via `uv pip install 'fastmcp>=3,<4'` before/after)