### PR TITLE
Reuse GraphQL session for auto connection pool management, GraphQL API error handling and relaying

### DIFF
--- a/src/open_targets_platform_mcp/client/graphql.py
+++ b/src/open_targets_platform_mcp/client/graphql.py
@@ -6,6 +6,7 @@ from gql.client import AsyncClientSession
 from gql.transport.aiohttp import AIOHTTPTransport
 from graphql import GraphQLSchema
 
+from open_targets_platform_mcp.model.exception import JqCompilationError
 from open_targets_platform_mcp.model.result import QueryResult
 from open_targets_platform_mcp.settings import settings
 
@@ -40,10 +41,16 @@ async def _get_global_graphql_session() -> AsyncClientSession:
 
 
 def _compile_jq_filter(jq_filter: str | None) -> object | None:
-    return None if jq_filter is None else cast("Any", jq.compile(jq_filter))  # pyright: ignore[reportUnknownMemberType]
+    if jq_filter is None:
+        return None
+
+    try:
+        return cast("Any", jq.compile(jq_filter))  # pyright: ignore[reportUnknownMemberType]
+    except Exception as e:
+        raise JqCompilationError(e) from e
 
 
-def _result_with_optional_filter(
+def _apply_optional_filter(
     result: object,
     compiled_filter: object | None,
     jq_filter: str | None,
@@ -60,23 +67,8 @@ def _result_with_optional_filter(
                 "Tip: Use '// empty' or '// []' to handle null values. "
                 f"Example: '{jq_filter} // empty'",
             )
-
-    return QueryResult.create_success(result)
-
-
-async def _execute_graphql_query_with_session(
-    session: AsyncClientSession,
-    query_string: str,
-    variables: dict[str, Any] | None = None,
-    jq_filter: str | None = None,
-) -> QueryResult:
-    query = gql(query_string)
-    compiled_filter = _compile_jq_filter(jq_filter)
-    request = GraphQLRequest(query, variable_values=variables)
-
-    result = await session.execute(request)
-
-    return _result_with_optional_filter(result, compiled_filter, jq_filter)
+    else:
+        return QueryResult.create_success(result)
 
 
 async def execute_graphql_query(
@@ -85,8 +77,19 @@ async def execute_graphql_query(
     jq_filter: str | None = None,
 ) -> QueryResult:
     """Make a generic GraphQL API call and apply a jq filter to the result."""
-    session = await _get_global_graphql_session()
-    return await _execute_graphql_query_with_session(session, query_string, variables, jq_filter)
+    try:
+        session = await _get_global_graphql_session()
+        query = gql(query_string)
+        compiled_filter = _compile_jq_filter(jq_filter)
+        request = GraphQLRequest(query, variable_values=variables)
+        result = await session.execute(request)
+        result = _apply_optional_filter(result, compiled_filter, jq_filter)
+    except Exception as exception:
+        result = QueryResult.create_error(
+            str(exception),
+            error_type=type(exception).__name__,
+        )
+    return result
 
 
 async def fetch_graphql_schema() -> GraphQLSchema:

--- a/src/open_targets_platform_mcp/client/graphql.py
+++ b/src/open_targets_platform_mcp/client/graphql.py
@@ -1,12 +1,97 @@
+from collections.abc import Sequence
 from typing import Any, cast
 
 import jq
-from gql import Client, gql
+from gql import Client, GraphQLRequest, gql
+from gql.client import AsyncClientSession
 from gql.transport.aiohttp import AIOHTTPTransport
 from graphql import GraphQLSchema
 
 from open_targets_platform_mcp.model.result import QueryResult
 from open_targets_platform_mcp.settings import settings
+
+_runtime_state: dict[str, Client | AsyncClientSession | None] = {
+    "client": None,
+    "session": None,
+}
+
+
+def _create_graphql_client(*, fetch_schema_from_transport: bool = False) -> Client:
+    """Create a configured gql client for the Open Targets endpoint."""
+    transport = AIOHTTPTransport(
+        url=str(settings.api_endpoint),
+        headers={
+            "Content-Type": "application/json",
+        },
+        timeout=settings.api_call_timeout,
+    )
+    return Client(transport=transport, fetch_schema_from_transport=fetch_schema_from_transport)
+
+
+async def _get_global_graphql_session() -> AsyncClientSession:
+    """Return a process-wide gql session for the app lifetime."""
+    session = cast("AsyncClientSession | None", _runtime_state["session"])
+    if session is None:
+        client = _create_graphql_client()
+        connected_session = await client.connect_async()  # pyright: ignore[reportUnknownMemberType]
+        _runtime_state["client"] = client
+        _runtime_state["session"] = cast("AsyncClientSession", connected_session)
+        session = cast("AsyncClientSession", connected_session)
+
+    return session
+
+
+def _compile_jq_filter(jq_filter: str | None) -> object | None:
+    return None if jq_filter is None else cast("Any", jq.compile(jq_filter))  # pyright: ignore[reportUnknownMemberType]
+
+
+def _result_with_optional_filter(
+    result: object,
+    compiled_filter: object | None,
+    jq_filter: str | None,
+) -> QueryResult:
+    if compiled_filter:
+        try:
+            filter_program = cast("Any", compiled_filter)
+            filtered_results = cast("list[Any]", filter_program.input_value(result).all())
+            return QueryResult.create_success(filtered_results)
+        except Exception as jq_error:  # noqa: BLE001
+            return QueryResult.create_warning(
+                result,
+                f"jq filter failed: {jq_error!s}. "
+                "Tip: Use '// empty' or '// []' to handle null values. "
+                f"Example: '{jq_filter} // empty'",
+            )
+
+    return QueryResult.create_success(result)
+
+
+async def _execute_graphql_query_with_session(
+    session: AsyncClientSession,
+    query_string: str,
+    variables: dict[str, Any] | None = None,
+    jq_filter: str | None = None,
+) -> QueryResult:
+    query = gql(query_string)
+    compiled_filter = _compile_jq_filter(jq_filter)
+
+    result = await session.execute(query, variable_values=variables)
+
+    return _result_with_optional_filter(result, compiled_filter, jq_filter)
+
+
+async def _execute_graphql_batch_query_with_session(
+    session: AsyncClientSession,
+    query_string: str,
+    variables_list: Sequence[dict[str, Any]],
+    jq_filter: str | None = None,
+) -> list[QueryResult]:
+    query = gql(query_string)
+    compiled_filter = _compile_jq_filter(jq_filter)
+    requests = [GraphQLRequest(query, variable_values=variables) for variables in variables_list]
+
+    raw_results = await session.execute_batch(requests)
+    return [_result_with_optional_filter(result, compiled_filter, jq_filter) for result in raw_results]
 
 
 async def execute_graphql_query(
@@ -24,33 +109,18 @@ async def execute_graphql_query(
     Returns:
         QueryResult: The result of the GraphQL query
     """
-    # Compile both the query and the jq filter before submitting a HTTP request
-    # to detect errors early.
-    query = gql(query_string)
-    compiled_filter = None if jq_filter is None else cast("Any", jq.compile(jq_filter))  # pyright: ignore[reportUnknownMemberType]
+    session = await _get_global_graphql_session()
+    return await _execute_graphql_query_with_session(session, query_string, variables, jq_filter)
 
-    transport = AIOHTTPTransport(
-        url=str(settings.api_endpoint),
-        headers={
-            "Content-Type": "application/json",
-        },
-        timeout=settings.api_call_timeout,
-    )
-    client = Client(transport=transport)
-    result = await client.execute_async(query, variable_values=variables)
 
-    if compiled_filter:
-        try:
-            filtered_results = cast("list[Any]", compiled_filter.input_value(result).all())
-            return QueryResult.create_success(filtered_results)
-        except Exception as jq_error:
-            return QueryResult.create_warning(
-                result,
-                f"jq filter failed: {jq_error!s}. "
-                "Tip: Use '// empty' or '// []' to handle null values. "
-                f"Example: '{jq_filter} // empty'",
-            )
-    return QueryResult.create_success(result)
+async def execute_graphql_batch_query(
+    query_string: str,
+    variables_list: Sequence[dict[str, Any]],
+    jq_filter: str | None = None,
+) -> list[QueryResult]:
+    """Execute one query with many variable sets, one result per set."""
+    session = await _get_global_graphql_session()
+    return await _execute_graphql_batch_query_with_session(session, query_string, variables_list, jq_filter)
 
 
 async def fetch_graphql_schema() -> GraphQLSchema:
@@ -65,17 +135,8 @@ async def fetch_graphql_schema() -> GraphQLSchema:
     Raises:
         ValueError: If the schema could not be fetched from the endpoint.
     """
-    # Create a transport with the GraphQL endpoint
-    transport = AIOHTTPTransport(
-        url=str(settings.api_endpoint),
-        headers={
-            "Content-Type": "application/json",
-        },
-        timeout=settings.api_call_timeout,
-    )
-
-    # Create a client with schema fetching enabled
-    client = Client(transport=transport, fetch_schema_from_transport=True)
+    # Create a client with schema fetching enabled.
+    client = _create_graphql_client(fetch_schema_from_transport=True)
 
     async with client:
         # The schema is automatically fetched and stored in the client

--- a/src/open_targets_platform_mcp/client/graphql.py
+++ b/src/open_targets_platform_mcp/client/graphql.py
@@ -10,14 +10,16 @@ from graphql import GraphQLSchema
 from open_targets_platform_mcp.model.result import QueryResult
 from open_targets_platform_mcp.settings import settings
 
-_runtime_state: dict[str, Client | AsyncClientSession | None] = {
-    "client": None,
-    "session": None,
-}
+
+class _RuntimeState:
+    client: Client | None = None
+    session: AsyncClientSession | None = None
+
+
+_runtime_state: _RuntimeState = _RuntimeState()
 
 
 def _create_graphql_client(*, fetch_schema_from_transport: bool = False) -> Client:
-    """Create a configured gql client for the Open Targets endpoint."""
     transport = AIOHTTPTransport(
         url=str(settings.api_endpoint),
         headers={
@@ -29,16 +31,13 @@ def _create_graphql_client(*, fetch_schema_from_transport: bool = False) -> Clie
 
 
 async def _get_global_graphql_session() -> AsyncClientSession:
-    """Return a process-wide gql session for the app lifetime."""
-    session = cast("AsyncClientSession | None", _runtime_state["session"])
-    if session is None:
+    if _runtime_state.session is None:
         client = _create_graphql_client()
         connected_session = await client.connect_async()  # pyright: ignore[reportUnknownMemberType]
-        _runtime_state["client"] = client
-        _runtime_state["session"] = cast("AsyncClientSession", connected_session)
-        session = cast("AsyncClientSession", connected_session)
+        _runtime_state.client = client
+        _runtime_state.session = cast("AsyncClientSession", connected_session)
 
-    return session
+    return _runtime_state.session
 
 
 def _compile_jq_filter(jq_filter: str | None) -> object | None:
@@ -74,8 +73,8 @@ async def _execute_graphql_query_with_session(
 ) -> QueryResult:
     query = gql(query_string)
     compiled_filter = _compile_jq_filter(jq_filter)
-
-    result = await session.execute(query, variable_values=variables)
+    request = GraphQLRequest(query, variable_values=variables)
+    result = await session.execute(request)
 
     return _result_with_optional_filter(result, compiled_filter, jq_filter)
 
@@ -89,8 +88,8 @@ async def _execute_graphql_batch_query_with_session(
     query = gql(query_string)
     compiled_filter = _compile_jq_filter(jq_filter)
     requests = [GraphQLRequest(query, variable_values=variables) for variables in variables_list]
-
     raw_results = await session.execute_batch(requests)
+
     return [_result_with_optional_filter(result, compiled_filter, jq_filter) for result in raw_results]
 
 
@@ -99,16 +98,7 @@ async def execute_graphql_query(
     variables: dict[str, Any] | None = None,
     jq_filter: str | None = None,
 ) -> QueryResult:
-    """Make a generic GraphQL API call and apply a jq filter to the result.
-
-    Args:
-        query_string (str): The GraphQL query or mutation as a string
-        variables (dict, optional): Variables for the GraphQL query
-        jq_filter (str, optional): jq filter to apply to the result
-
-    Returns:
-        QueryResult: The result of the GraphQL query
-    """
+    """Make a generic GraphQL API call and apply a jq filter to the result."""
     session = await _get_global_graphql_session()
     return await _execute_graphql_query_with_session(session, query_string, variables, jq_filter)
 
@@ -124,17 +114,7 @@ async def execute_graphql_batch_query(
 
 
 async def fetch_graphql_schema() -> GraphQLSchema:
-    """Fetch the GraphQL schema from the configured endpoint URL.
-
-    Uses the gql client's built-in schema fetching capability to retrieve
-    the schema automatically via introspection.
-
-    Returns:
-        str: The GraphQL schema in SDL (Schema Definition Language) format.
-
-    Raises:
-        ValueError: If the schema could not be fetched from the endpoint.
-    """
+    """Fetch the GraphQL schema from the configured endpoint URL."""
     # Create a client with schema fetching enabled.
     client = _create_graphql_client(fetch_schema_from_transport=True)
 

--- a/src/open_targets_platform_mcp/client/graphql.py
+++ b/src/open_targets_platform_mcp/client/graphql.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from typing import Any, cast
 
 import jq
@@ -74,23 +73,10 @@ async def _execute_graphql_query_with_session(
     query = gql(query_string)
     compiled_filter = _compile_jq_filter(jq_filter)
     request = GraphQLRequest(query, variable_values=variables)
+
     result = await session.execute(request)
 
     return _result_with_optional_filter(result, compiled_filter, jq_filter)
-
-
-async def _execute_graphql_batch_query_with_session(
-    session: AsyncClientSession,
-    query_string: str,
-    variables_list: Sequence[dict[str, Any]],
-    jq_filter: str | None = None,
-) -> list[QueryResult]:
-    query = gql(query_string)
-    compiled_filter = _compile_jq_filter(jq_filter)
-    requests = [GraphQLRequest(query, variable_values=variables) for variables in variables_list]
-    raw_results = await session.execute_batch(requests)
-
-    return [_result_with_optional_filter(result, compiled_filter, jq_filter) for result in raw_results]
 
 
 async def execute_graphql_query(
@@ -101,16 +87,6 @@ async def execute_graphql_query(
     """Make a generic GraphQL API call and apply a jq filter to the result."""
     session = await _get_global_graphql_session()
     return await _execute_graphql_query_with_session(session, query_string, variables, jq_filter)
-
-
-async def execute_graphql_batch_query(
-    query_string: str,
-    variables_list: Sequence[dict[str, Any]],
-    jq_filter: str | None = None,
-) -> list[QueryResult]:
-    """Execute one query with many variable sets, one result per set."""
-    session = await _get_global_graphql_session()
-    return await _execute_graphql_batch_query_with_session(session, query_string, variables_list, jq_filter)
 
 
 async def fetch_graphql_schema() -> GraphQLSchema:

--- a/src/open_targets_platform_mcp/model/exception.py
+++ b/src/open_targets_platform_mcp/model/exception.py
@@ -1,0 +1,8 @@
+class JqCompilationError(Exception):
+    """Raised when a jq filter cannot be compiled."""
+
+    def __init__(self, inner_exception: Exception | None = None) -> None:
+        super().__init__(str(inner_exception))
+        self.inner_exception = inner_exception
+
+    inner_exception: Exception | None

--- a/src/open_targets_platform_mcp/tools/batch_query/batch_query.py
+++ b/src/open_targets_platform_mcp/tools/batch_query/batch_query.py
@@ -1,11 +1,10 @@
 """Batch query execution tool for Open Targets Platform GraphQL API."""
 
-import asyncio
 from typing import Annotated, Any
 
 from pydantic import Field
 
-from open_targets_platform_mcp.client.graphql import execute_graphql_query
+from open_targets_platform_mcp.client.graphql import execute_graphql_batch_query
 from open_targets_platform_mcp.model.result import (
     BatchQueryResult,
     BatchQuerySingleResult,
@@ -15,30 +14,13 @@ from open_targets_platform_mcp.model.result import (
 )
 
 
-async def _handle_single_query(
-    index: int,
-    query_string: str,
-    variables: dict[str, Any],
-    key_field: str,
-    jq_filter: str | None,
-    semaphore: asyncio.Semaphore,
-) -> BatchQuerySingleResult:
-    async with semaphore:
-        result: QueryResult | None = None
-        key: str | None = None
-        if key_field not in variables:
-            key = None
-            result = QueryResult.create_error(
-                f"Key field '{key_field}' not found in variables at index {index}",
-                variables=variables,
-            )
-        else:
-            key = str(variables[key_field])
-            result = await execute_graphql_query(query_string, variables, jq_filter=jq_filter)
-            if result.status in (QueryResultStatus.ERROR, QueryResultStatus.WARNING):
-                result = result.model_copy(update={"variables": variables})
-
-        return BatchQuerySingleResult(index=index, key=key, result=result)
+def _build_summary(results: list[BatchQuerySingleResult], total: int) -> BatchQuerySummary:
+    return BatchQuerySummary(
+        total=total,
+        successful=len([result for result in results if result.result.status == QueryResultStatus.SUCCESS]),
+        failed=len([result for result in results if result.result.status == QueryResultStatus.ERROR]),
+        warning=len([result for result in results if result.result.status == QueryResultStatus.WARNING]),
+    )
 
 
 async def _batch_query_impl(
@@ -51,22 +33,43 @@ async def _batch_query_impl(
     if not variables_list:
         return QueryResult.create_error("variables_list cannot be empty")
 
-    # serialising the execution for now before the GraphQL client cache is
-    # implemented.
-    semaphore = asyncio.Semaphore(1)
-    tasks = [
-        _handle_single_query(idx, query_string, variables, key_field, jq_filter, semaphore)
-        for idx, variables in enumerate(variables_list)
-    ]
-    results = await asyncio.gather(*tasks)
+    results: list[BatchQuerySingleResult] = []
+    valid_indices: list[int] = []
+    valid_variables_list: list[dict[str, Any]] = []
+
+    for idx, variables in enumerate(variables_list):
+        if key_field not in variables:
+            results.append(
+                BatchQuerySingleResult(
+                    index=idx,
+                    key=None,
+                    result=QueryResult.create_error(
+                        f"Key field '{key_field}' not found in variables at index {idx}",
+                        variables=variables,
+                    ),
+                ),
+            )
+            continue
+
+        valid_indices.append(idx)
+        valid_variables_list.append(variables)
+
+    if valid_variables_list:
+        query_results = await execute_graphql_batch_query(query_string, valid_variables_list, jq_filter)
+
+        for idx, variables, result_item in zip(valid_indices, valid_variables_list, query_results, strict=True):
+            key = str(variables[key_field])
+            processed_result = result_item
+            if result_item.status in (QueryResultStatus.ERROR, QueryResultStatus.WARNING):
+                processed_result = result_item.model_copy(update={"variables": variables})
+
+            results.append(BatchQuerySingleResult(index=idx, key=key, result=processed_result))
+
+    results.sort(key=lambda item: item.index)
+
     return BatchQueryResult(
         results=results,
-        summary=BatchQuerySummary(
-            total=len(variables_list),
-            successful=len([result for result in results if result.result.status == QueryResultStatus.SUCCESS]),
-            failed=len([result for result in results if result.result.status == QueryResultStatus.ERROR]),
-            warning=len([result for result in results if result.result.status == QueryResultStatus.WARNING]),
-        ),
+        summary=_build_summary(results, len(variables_list)),
     )
 
 

--- a/src/open_targets_platform_mcp/tools/batch_query/batch_query.py
+++ b/src/open_targets_platform_mcp/tools/batch_query/batch_query.py
@@ -1,10 +1,11 @@
 """Batch query execution tool for Open Targets Platform GraphQL API."""
 
+import asyncio
 from typing import Annotated, Any
 
 from pydantic import Field
 
-from open_targets_platform_mcp.client.graphql import execute_graphql_batch_query
+from open_targets_platform_mcp.client.graphql import execute_graphql_query
 from open_targets_platform_mcp.model.result import (
     BatchQueryResult,
     BatchQuerySingleResult,
@@ -14,13 +15,30 @@ from open_targets_platform_mcp.model.result import (
 )
 
 
-def _build_summary(results: list[BatchQuerySingleResult], total: int) -> BatchQuerySummary:
-    return BatchQuerySummary(
-        total=total,
-        successful=len([result for result in results if result.result.status == QueryResultStatus.SUCCESS]),
-        failed=len([result for result in results if result.result.status == QueryResultStatus.ERROR]),
-        warning=len([result for result in results if result.result.status == QueryResultStatus.WARNING]),
-    )
+async def _handle_single_query(
+    index: int,
+    query_string: str,
+    variables: dict[str, Any],
+    key_field: str,
+    jq_filter: str | None,
+    semaphore: asyncio.Semaphore,
+) -> BatchQuerySingleResult:
+    async with semaphore:
+        result: QueryResult | None = None
+        key: str | None = None
+        if key_field not in variables:
+            key = None
+            result = QueryResult.create_error(
+                f"Key field '{key_field}' not found in variables at index {index}",
+                variables=variables,
+            )
+        else:
+            key = str(variables[key_field])
+            result = await execute_graphql_query(query_string, variables, jq_filter=jq_filter)
+            if result.status in (QueryResultStatus.ERROR, QueryResultStatus.WARNING):
+                result = result.model_copy(update={"variables": variables})
+
+        return BatchQuerySingleResult(index=index, key=key, result=result)
 
 
 async def _batch_query_impl(
@@ -33,43 +51,22 @@ async def _batch_query_impl(
     if not variables_list:
         return QueryResult.create_error("variables_list cannot be empty")
 
-    results: list[BatchQuerySingleResult] = []
-    valid_indices: list[int] = []
-    valid_variables_list: list[dict[str, Any]] = []
-
-    for idx, variables in enumerate(variables_list):
-        if key_field not in variables:
-            results.append(
-                BatchQuerySingleResult(
-                    index=idx,
-                    key=None,
-                    result=QueryResult.create_error(
-                        f"Key field '{key_field}' not found in variables at index {idx}",
-                        variables=variables,
-                    ),
-                ),
-            )
-            continue
-
-        valid_indices.append(idx)
-        valid_variables_list.append(variables)
-
-    if valid_variables_list:
-        query_results = await execute_graphql_batch_query(query_string, valid_variables_list, jq_filter)
-
-        for idx, variables, result_item in zip(valid_indices, valid_variables_list, query_results, strict=True):
-            key = str(variables[key_field])
-            processed_result = result_item
-            if result_item.status in (QueryResultStatus.ERROR, QueryResultStatus.WARNING):
-                processed_result = result_item.model_copy(update={"variables": variables})
-
-            results.append(BatchQuerySingleResult(index=idx, key=key, result=processed_result))
-
-    results.sort(key=lambda item: item.index)
-
+    # GraphQL API does not support batch operations,
+    # serialising the execution to avoid exhausting connections
+    semaphore = asyncio.Semaphore(1)
+    tasks = [
+        _handle_single_query(idx, query_string, variables, key_field, jq_filter, semaphore)
+        for idx, variables in enumerate(variables_list)
+    ]
+    results = await asyncio.gather(*tasks)
     return BatchQueryResult(
         results=results,
-        summary=_build_summary(results, len(variables_list)),
+        summary=BatchQuerySummary(
+            total=len(variables_list),
+            successful=len([result for result in results if result.result.status == QueryResultStatus.SUCCESS]),
+            failed=len([result for result in results if result.result.status == QueryResultStatus.ERROR]),
+            warning=len([result for result in results if result.result.status == QueryResultStatus.WARNING]),
+        ),
     )
 
 

--- a/src/open_targets_platform_mcp/tools/query/query.py
+++ b/src/open_targets_platform_mcp/tools/query/query.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
-from open_targets_platform_mcp.client import execute_graphql_query
+from open_targets_platform_mcp.client.graphql import execute_graphql_query
 from open_targets_platform_mcp.model.result import QueryResult
 
 
@@ -13,11 +13,7 @@ async def _query_impl(
     variables: dict[str, Any] | None = None,
     jq_filter: str | None = None,
 ) -> QueryResult:
-    return await execute_graphql_query(
-        query_string,
-        variables,
-        jq_filter=jq_filter,
-    )
+    return await execute_graphql_query(query_string, variables, jq_filter=jq_filter)
 
 
 async def query_with_jq(

--- a/test/test_client/test_graphql.py
+++ b/test/test_client/test_graphql.py
@@ -77,27 +77,28 @@ class TestExecuteGraphQLQuery:
 
     @pytest.mark.asyncio
     async def test_execute_query_invalid_query_string(self):
-        """Test that invalid GraphQL query string errors bubble up."""
+        """Test that invalid GraphQL query strings return structured errors."""
         invalid_query = "this is not valid graphql"
 
         with patch("open_targets_platform_mcp.client.graphql.gql", side_effect=Exception("Parse error")):
-            with pytest.raises(Exception, match="Parse error"):
-                await execute_graphql_query(invalid_query)
+            result = await execute_graphql_query(invalid_query)
+
+        assert result.status == QueryResultStatus.ERROR
+        assert "Parse error" in str(result.message)
 
     @pytest.mark.asyncio
     async def test_execute_query_execution_error(self, sample_query_string):
-        """Test that query execution errors bubble up."""
+        """Test that query execution errors return structured errors."""
         mock_session = _make_mock_session(side_effect=Exception("Network error"))
 
-        with (
-            patch(
-                "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
-                return_value=mock_session,
-            ),
-            pytest.raises(Exception, match="Network error"),
+        with patch(
+            "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+            return_value=mock_session,
         ):
-            await execute_graphql_query(sample_query_string)
+            result = await execute_graphql_query(sample_query_string)
 
+        assert result.status == QueryResultStatus.ERROR
+        assert "Network error" in str(result.message)
         mock_session.execute.assert_awaited_once()
 
 
@@ -201,7 +202,7 @@ class TestJQFiltering:
             ),
             patch("open_targets_platform_mcp.client.graphql.jq.compile") as mock_jq_compile,
         ):
-            mock_compiled_filter = AsyncMock()
+            mock_compiled_filter = Mock()
             mock_compiled_filter.input_value.return_value.all.side_effect = Exception("jq execution error")
             mock_jq_compile.return_value = mock_compiled_filter
 
@@ -215,13 +216,15 @@ class TestJQFiltering:
 
     @pytest.mark.asyncio
     async def test_execute_query_jq_compilation_error(self, sample_query_string):
-        """Test that jq compilation errors bubble up."""
+        """Test that jq compilation errors return structured errors."""
         # Mock jq.compile to raise an error during compilation
         with patch("open_targets_platform_mcp.client.graphql.jq.compile") as mock_jq:
             mock_jq.side_effect = Exception("jq compilation error")
 
-            with pytest.raises(Exception, match="jq compilation error"):
-                await execute_graphql_query(sample_query_string, jq_filter=".invalid_filter")
+            result = await execute_graphql_query(sample_query_string, jq_filter=".invalid_filter")
+
+        assert result.status == QueryResultStatus.ERROR
+        assert "jq compilation error" in str(result.message)
 
     @pytest.mark.asyncio
     async def test_execute_query_no_jq_filter(self, sample_query_string, sample_graphql_response):
@@ -308,9 +311,7 @@ class TestGraphQLIntegration:
 
     @pytest.mark.asyncio
     async def test_real_invalid_query(self):
-        """Test that invalid query raises exception."""
-        from gql.transport.exceptions import TransportQueryError
-
+        """Test that invalid query returns error result."""
         invalid_query = """
         query {
             nonexistentField {
@@ -319,8 +320,8 @@ class TestGraphQLIntegration:
         }
         """
 
-        with pytest.raises(TransportQueryError):
-            await execute_graphql_query(invalid_query)
+        result = await execute_graphql_query(invalid_query)
+        assert result.status == QueryResultStatus.ERROR
 
 
 # ============================================================================

--- a/test/test_client/test_graphql.py
+++ b/test/test_client/test_graphql.py
@@ -13,11 +13,11 @@ from open_targets_platform_mcp.model.result import QueryResultStatus
 @pytest.fixture(autouse=True)
 def reset_graphql_session():
     """Reset the global gql session between tests."""
-    graphql_module._runtime_state["client"] = None
-    graphql_module._runtime_state["session"] = None
+    graphql_module._runtime_state.client = None
+    graphql_module._runtime_state.session = None
     yield
-    graphql_module._runtime_state["client"] = None
-    graphql_module._runtime_state["session"] = None
+    graphql_module._runtime_state.client = None
+    graphql_module._runtime_state.session = None
 
 
 def _make_mock_session(return_value=None, side_effect=None):
@@ -71,8 +71,9 @@ class TestExecuteGraphQLQuery:
 
         assert result.status == QueryResultStatus.SUCCESS
         mock_session.execute.assert_awaited_once()
-        _, kwargs = mock_session.execute.call_args
-        assert kwargs["variable_values"] == sample_variables
+        (request,), kwargs = mock_session.execute.call_args
+        assert kwargs == {}
+        assert request.variable_values == sample_variables
 
     @pytest.mark.asyncio
     async def test_execute_query_invalid_query_string(self):

--- a/test/test_client/test_graphql.py
+++ b/test/test_client/test_graphql.py
@@ -5,8 +5,30 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from graphql import GraphQLSchema
 
+from open_targets_platform_mcp.client import graphql as graphql_module
 from open_targets_platform_mcp.client.graphql import execute_graphql_query, fetch_graphql_schema
 from open_targets_platform_mcp.model.result import QueryResultStatus
+
+
+@pytest.fixture(autouse=True)
+def reset_graphql_session():
+    """Reset the global gql session between tests."""
+    graphql_module._runtime_state["client"] = None
+    graphql_module._runtime_state["session"] = None
+    yield
+    graphql_module._runtime_state["client"] = None
+    graphql_module._runtime_state["session"] = None
+
+
+def _make_mock_session(return_value=None, side_effect=None):
+    """Return a mock AsyncClientSession with execute pre-configured."""
+    session = AsyncMock()
+    if side_effect is not None:
+        session.execute = AsyncMock(side_effect=side_effect)
+    else:
+        session.execute = AsyncMock(return_value=return_value)
+    return session
+
 
 # ============================================================================
 # execute_graphql_query Tests - Unit Tests with Mocks
@@ -19,16 +41,17 @@ class TestExecuteGraphQLQuery:
     @pytest.mark.asyncio
     async def test_execute_query_success(self, sample_query_string, sample_graphql_response):
         """Test successful query execution."""
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value=sample_graphql_response)
+        mock_session = _make_mock_session(return_value=sample_graphql_response)
 
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                result = await execute_graphql_query(sample_query_string)
+        with patch(
+            "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+            return_value=mock_session,
+        ):
+            result = await execute_graphql_query(sample_query_string)
 
         assert result.status == QueryResultStatus.SUCCESS
         assert result.result == sample_graphql_response
-        mock_client_instance.execute_async.assert_awaited_once()
+        mock_session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_execute_query_with_variables(
@@ -38,29 +61,18 @@ class TestExecuteGraphQLQuery:
         sample_graphql_response,
     ):
         """Test query execution with variables."""
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value=sample_graphql_response)
+        mock_session = _make_mock_session(return_value=sample_graphql_response)
 
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                result = await execute_graphql_query(sample_query_string, variables=sample_variables)
+        with patch(
+            "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+            return_value=mock_session,
+        ):
+            result = await execute_graphql_query(sample_query_string, variables=sample_variables)
 
         assert result.status == QueryResultStatus.SUCCESS
-        mock_client_instance.execute_async.assert_awaited_once_with("parsed_query", variable_values=sample_variables)
-
-    @pytest.mark.asyncio
-    async def test_execute_query_default_headers(self, sample_query_string):
-        """Test that default headers are set when none provided."""
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value={})
-
-        with patch("open_targets_platform_mcp.client.graphql.AIOHTTPTransport") as mock_transport:
-            with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-                with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                    await execute_graphql_query(sample_query_string)
-
-        call_kwargs = mock_transport.call_args[1]
-        assert call_kwargs["headers"] == {"Content-Type": "application/json"}
+        mock_session.execute.assert_awaited_once()
+        _, kwargs = mock_session.execute.call_args
+        assert kwargs["variable_values"] == sample_variables
 
     @pytest.mark.asyncio
     async def test_execute_query_invalid_query_string(self):
@@ -74,15 +86,31 @@ class TestExecuteGraphQLQuery:
     @pytest.mark.asyncio
     async def test_execute_query_execution_error(self, sample_query_string):
         """Test that query execution errors bubble up."""
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(side_effect=Exception("Network error"))
+        mock_session = _make_mock_session(side_effect=Exception("Network error"))
 
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                with pytest.raises(Exception, match="Network error"):
-                    await execute_graphql_query(sample_query_string)
+        with (
+            patch(
+                "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+                return_value=mock_session,
+            ),
+            pytest.raises(Exception, match="Network error"),
+        ):
+            await execute_graphql_query(sample_query_string)
 
-        mock_client_instance.execute_async.assert_awaited_once()
+        mock_session.execute.assert_awaited_once()
+
+
+class TestTransportConstruction:
+    """Tests for transport/client construction."""
+
+    def test_create_client_sets_content_type_header(self):
+        """Test that _create_graphql_client uses the correct Content-Type header."""
+        with patch("open_targets_platform_mcp.client.graphql.AIOHTTPTransport") as mock_transport:
+            with patch("open_targets_platform_mcp.client.graphql.Client"):
+                graphql_module._create_graphql_client()
+
+        call_kwargs = mock_transport.call_args[1]
+        assert call_kwargs["headers"] == {"Content-Type": "application/json"}
 
 
 # ============================================================================
@@ -99,19 +127,18 @@ class TestJQFiltering:
         mock_response = {
             "target": {"id": "ENSG00000141510", "approvedSymbol": "TP53", "approvedName": "tumor protein p53"},
         }
+        mock_session = _make_mock_session(return_value=mock_response)
 
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value=mock_response)
+        with patch(
+            "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+            return_value=mock_session,
+        ):
+            result = await execute_graphql_query(sample_query_string, jq_filter=".target.id")
 
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                result = await execute_graphql_query(sample_query_string, jq_filter=".target.id")
-
-        # jq filter returns a list (even for single results)
         assert result.status == QueryResultStatus.SUCCESS
         assert isinstance(result.result, list)
         assert result.result == ["ENSG00000141510"]
-        mock_client_instance.execute_async.assert_awaited_once()
+        mock_session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_execute_query_with_complex_jq_filter(self, sample_query_string):
@@ -119,27 +146,24 @@ class TestJQFiltering:
         mock_response = {
             "target": {"id": "ENSG00000141510", "approvedSymbol": "TP53", "approvedName": "tumor protein p53"},
         }
+        mock_session = _make_mock_session(return_value=mock_response)
 
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value=mock_response)
+        with patch(
+            "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+            return_value=mock_session,
+        ):
+            result = await execute_graphql_query(
+                sample_query_string,
+                jq_filter=".target | {id, symbol: .approvedSymbol}",
+            )
 
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                result = await execute_graphql_query(
-                    sample_query_string,
-                    jq_filter=".target | {id, symbol: .approvedSymbol}",
-                )
-
-        # jq filter returns a list (even for single results)
         assert result.status == QueryResultStatus.SUCCESS
         assert isinstance(result.result, list)
         assert len(result.result) == 1
         assert isinstance(result.result[0], dict)
-        assert "id" in result.result[0]
-        assert "symbol" in result.result[0]
         assert result.result[0]["id"] == "ENSG00000141510"
         assert result.result[0]["symbol"] == "TP53"
-        mock_client_instance.execute_async.assert_awaited_once()
+        mock_session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_execute_query_with_array_jq_filter(self, sample_query_string):
@@ -150,45 +174,43 @@ class TestJQFiltering:
                 {"id": "ENSG00000012048", "approvedSymbol": "BRCA1"},
             ],
         }
+        mock_session = _make_mock_session(return_value=mock_response)
 
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value=mock_response)
+        with patch(
+            "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+            return_value=mock_session,
+        ):
+            result = await execute_graphql_query(sample_query_string, jq_filter=".targets[] | .approvedSymbol")
 
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                result = await execute_graphql_query(sample_query_string, jq_filter=".targets[] | .approvedSymbol")
-
-        # Multiple results should be in result list
         assert result.status == QueryResultStatus.SUCCESS
         assert isinstance(result.result, list)
         assert result.result == ["TP53", "BRCA1"]
-        mock_client_instance.execute_async.assert_awaited_once()
+        mock_session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_execute_query_jq_filter_error_handling(self, sample_query_string):
         """Test that jq filter runtime errors are handled gracefully."""
         mock_response = {"target": {"id": "ENSG00000141510"}}
+        mock_session = _make_mock_session(return_value=mock_response)
 
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value=mock_response)
+        with (
+            patch(
+                "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+                return_value=mock_session,
+            ),
+            patch("open_targets_platform_mcp.client.graphql.jq.compile") as mock_jq_compile,
+        ):
+            mock_compiled_filter = AsyncMock()
+            mock_compiled_filter.input_value.return_value.all.side_effect = Exception("jq execution error")
+            mock_jq_compile.return_value = mock_compiled_filter
 
-        # Mock jq filter to raise an error during execution (not compilation)
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                with patch("open_targets_platform_mcp.client.graphql.jq.compile") as mock_jq_compile:
-                    # Create a mock compiled filter that raises an error when used
-                    mock_compiled_filter = AsyncMock()
-                    mock_compiled_filter.input_value.return_value.all.side_effect = Exception("jq execution error")
-                    mock_jq_compile.return_value = mock_compiled_filter
+            result = await execute_graphql_query(sample_query_string, jq_filter=".invalid_filter")
 
-                    result = await execute_graphql_query(sample_query_string, jq_filter=".invalid_filter")
-
-        # Should return warning with original data
         assert result.status == QueryResultStatus.WARNING
         assert result.result == mock_response
         assert "jq filter failed" in str(result.message)
-        assert "// empty" in str(result.message)  # Should suggest null handling
-        mock_client_instance.execute_async.assert_awaited_once()
+        assert "// empty" in str(result.message)
+        mock_session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_execute_query_jq_compilation_error(self, sample_query_string):
@@ -203,16 +225,17 @@ class TestJQFiltering:
     @pytest.mark.asyncio
     async def test_execute_query_no_jq_filter(self, sample_query_string, sample_graphql_response):
         """Test query execution without jq filter returns full response."""
-        mock_client_instance = AsyncMock()
-        mock_client_instance.execute_async = AsyncMock(return_value=sample_graphql_response)
+        mock_session = _make_mock_session(return_value=sample_graphql_response)
 
-        with patch("open_targets_platform_mcp.client.graphql.gql", return_value="parsed_query"):
-            with patch("open_targets_platform_mcp.client.graphql.Client", return_value=mock_client_instance):
-                result = await execute_graphql_query(sample_query_string)
+        with patch(
+            "open_targets_platform_mcp.client.graphql._get_global_graphql_session",
+            return_value=mock_session,
+        ):
+            result = await execute_graphql_query(sample_query_string)
 
         assert result.status == QueryResultStatus.SUCCESS
         assert result.result == sample_graphql_response
-        mock_client_instance.execute_async.assert_awaited_once()
+        mock_session.execute.assert_awaited_once()
 
 
 # ============================================================================

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -30,7 +30,7 @@ class TestCreateServer:
     @pytest.mark.asyncio
     async def test_all_tools_have_readonly_hint(self):
         """Test that all registered tools have readOnlyHint set to True."""
-        server = create_server()
+        server = await create_server()
         tools = await server.get_tools()
 
         # Ensure at least one tool is registered

--- a/test/test_tools/test_batch_query.py
+++ b/test/test_tools/test_batch_query.py
@@ -1,6 +1,6 @@
 """Tests for batch query tool."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
@@ -29,10 +29,10 @@ class TestBatchQueryOpenTargetsGraphQL:
     async def test_batch_query_success(self, batch_query_string, batch_variables_with_key):
         """Test successful batch query execution."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510", "approvedSymbol": "TP53"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000012048", "approvedSymbol": "BRCA1"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618", "approvedSymbol": "BRCA2"}}),
@@ -54,6 +54,7 @@ class TestBatchQueryOpenTargetsGraphQL:
         assert "ENSG00000141510" in result_dict
         assert "ENSG00000012048" in result_dict
         assert "ENSG00000139618" in result_dict
+        assert mock_execute.call_count == 3
 
     @pytest.mark.asyncio
     async def test_batch_query_empty_variables_list(self, batch_query_string):
@@ -74,10 +75,10 @@ class TestBatchQueryOpenTargetsGraphQL:
         ]
 
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
             ]
@@ -98,15 +99,16 @@ class TestBatchQueryOpenTargetsGraphQL:
         assert error_result.key is None
         assert error_result.result.status == QueryResultStatus.ERROR
         assert "not found" in str(error_result.result.message)
+        assert mock_execute.call_count == 2
 
     @pytest.mark.asyncio
     async def test_batch_query_partial_failures(self, batch_query_string, batch_variables_with_key):
         """Test batch query with some queries failing."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_error("Query failed"),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
@@ -137,10 +139,10 @@ class TestBatchQueryOpenTargetsGraphQL:
         including correct data for successes and error details for failures.
         """
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510", "approvedSymbol": "TP53"}}),
                 QueryResult.create_error("Upstream error for BRCA1"),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618", "approvedSymbol": "BRCA2"}}),
@@ -183,10 +185,10 @@ class TestBatchQueryOpenTargetsGraphQL:
         jq_filter = ".data.target.approvedSymbol"
 
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success("TP53"),
                 QueryResult.create_success("BRCA1"),
                 QueryResult.create_success("BRCA2"),
@@ -199,12 +201,12 @@ class TestBatchQueryOpenTargetsGraphQL:
                 jq_filter=jq_filter,
             )
 
-        # Verify jq_filter was passed to execute_graphql_batch_query
-        mock_execute.assert_called_once_with(
-            batch_query_string,
-            batch_variables_with_key,
-            jq_filter,
-        )
+        # Verify jq_filter was passed to each query invocation
+        expected_calls = [
+            call(batch_query_string, variables, jq_filter=jq_filter) for variables in batch_variables_with_key
+        ]
+        mock_execute.assert_has_calls(expected_calls)
+        assert mock_execute.call_count == 3
 
         assert isinstance(result, BatchQueryResult)
         assert result.summary.successful == 3
@@ -213,10 +215,10 @@ class TestBatchQueryOpenTargetsGraphQL:
     async def test_batch_query_without_jq_filter(self, batch_query_string, batch_variables_with_key):
         """Test batch query without jq filter."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000012048"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
@@ -229,12 +231,10 @@ class TestBatchQueryOpenTargetsGraphQL:
                 jq_filter=None,
             )
 
-        # Verify jq_filter was passed as None
-        mock_execute.assert_called_once_with(
-            batch_query_string,
-            batch_variables_with_key,
-            None,
-        )
+        # Verify jq_filter was passed as None to each query
+        expected_calls = [call(batch_query_string, variables, jq_filter=None) for variables in batch_variables_with_key]
+        mock_execute.assert_has_calls(expected_calls)
+        assert mock_execute.call_count == 3
 
         assert isinstance(result, BatchQueryResult)
         assert result.summary.successful == 3
@@ -243,10 +243,10 @@ class TestBatchQueryOpenTargetsGraphQL:
     async def test_batch_query_exception_handling(self, batch_query_string, batch_variables_with_key):
         """Test that error results during batch query execution are handled."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_error("Network error"),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
@@ -271,12 +271,12 @@ class TestBatchQueryOpenTargetsGraphQL:
 
     @pytest.mark.asyncio
     async def test_batch_query_calls_execute_correctly(self, batch_query_string, batch_variables_with_key):
-        """Test that batch query calls execute_graphql_batch_query correctly."""
+        """Test that batch query calls execute_graphql_query correctly."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [QueryResult.create_success({})]
+            mock_execute.return_value = QueryResult.create_success({})
 
             await batch_query_fn(
                 query_string=batch_query_string,
@@ -287,22 +287,18 @@ class TestBatchQueryOpenTargetsGraphQL:
             # Verify the function was called with correct arguments
             mock_execute.assert_called_once_with(
                 batch_query_string,
-                [batch_variables_with_key[0]],
-                None,
+                batch_variables_with_key[0],
+                jq_filter=None,
             )
 
     @pytest.mark.asyncio
-    async def test_batch_query_parallel_execution(self, batch_query_string, batch_variables_with_key):
-        """Test that all variables are passed in a single batch call."""
+    async def test_batch_query_iterates_all_variables(self, batch_query_string, batch_variables_with_key):
+        """Test that each variables entry is passed to execute_graphql_query."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
-                QueryResult.create_success({}),
-                QueryResult.create_success({}),
-                QueryResult.create_success({}),
-            ]
+            mock_execute.side_effect = [QueryResult.create_success({})] * 3
 
             await batch_query_fn(
                 query_string=batch_query_string,
@@ -310,18 +306,19 @@ class TestBatchQueryOpenTargetsGraphQL:
                 key_field="ensemblId",
             )
 
-        # Verify all variables were passed in a single call
-        mock_execute.assert_called_once()
-        assert mock_execute.call_args.args[1] == batch_variables_with_key
+        # Verify each variables payload was passed in order
+        expected_calls = [call(batch_query_string, variables, jq_filter=None) for variables in batch_variables_with_key]
+        mock_execute.assert_has_calls(expected_calls)
+        assert mock_execute.call_count == 3
 
     @pytest.mark.asyncio
     async def test_batch_query_result_structure(self, batch_query_string, batch_variables_with_key):
         """Test the structure of batch query results."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_execute.side_effect = [
                 QueryResult.create_success({"target": {"id": "test"}}),
                 QueryResult.create_success({"target": {"id": "test"}}),
                 QueryResult.create_success({"target": {"id": "test"}}),
@@ -348,15 +345,13 @@ class TestBatchQueryOpenTargetsGraphQL:
     async def test_batch_query_jq_filter_warning(self, batch_query_string, batch_variables_with_key):
         """Test that jq filter warnings are preserved in results."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = [
-                QueryResult.create_warning(
-                    {"target": {"id": "test"}},
-                    "jq filter failed: null value",
-                ),
-            ]
+            mock_execute.return_value = QueryResult.create_warning(
+                {"target": {"id": "test"}},
+                "jq filter failed: null value",
+            )
 
             result = await batch_query_fn(
                 query_string=batch_query_string,
@@ -382,10 +377,8 @@ class TestBatchQueryIntegration:
     """Integration tests with real API calls."""
 
     @pytest.mark.asyncio
-    async def test_real_batch_query_raises_on_unsupported_api(self):
-        """The Open Targets Platform API does not support native batch queries."""
-        from gql.transport.exceptions import TransportConnectionFailed, TransportServerError
-
+    async def test_real_batch_query_executes_per_item(self):
+        """Batch helper should execute single-item queries and return a batch result."""
         query = """
         query GetTarget($ensemblId: String!) {
             target(ensemblId: $ensemblId) {
@@ -400,5 +393,8 @@ class TestBatchQueryIntegration:
             {"ensemblId": "ENSG00000012048"},
         ]
 
-        with pytest.raises((TransportServerError, TransportConnectionFailed, Exception)):
-            await batch_query_fn(query_string=query, variables_list=variables_list, key_field="ensemblId")
+        result = await batch_query_fn(query_string=query, variables_list=variables_list, key_field="ensemblId")
+
+        assert isinstance(result, BatchQueryResult)
+        assert result.summary.total == 2
+        assert len(result.results) == 2

--- a/test/test_tools/test_batch_query.py
+++ b/test/test_tools/test_batch_query.py
@@ -15,11 +15,11 @@ batch_query_fn = _batch_query_impl
 @pytest.fixture(autouse=True)
 def reset_graphql_session():
     """Reset the global gql session between tests."""
-    graphql_module._runtime_state["client"] = None
-    graphql_module._runtime_state["session"] = None
+    graphql_module._runtime_state.client = None
+    graphql_module._runtime_state.session = None
     yield
-    graphql_module._runtime_state["client"] = None
-    graphql_module._runtime_state["session"] = None
+    graphql_module._runtime_state.client = None
+    graphql_module._runtime_state.session = None
 
 
 class TestBatchQueryOpenTargetsGraphQL:

--- a/test/test_tools/test_batch_query.py
+++ b/test/test_tools/test_batch_query.py
@@ -4,11 +4,22 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from open_targets_platform_mcp.client import graphql as graphql_module
 from open_targets_platform_mcp.model.result import BatchQueryResult, QueryResult, QueryResultStatus
 from open_targets_platform_mcp.tools.batch_query.batch_query import _batch_query_impl
 
 # Use the internal implementation function directly for testing
 batch_query_fn = _batch_query_impl
+
+
+@pytest.fixture(autouse=True)
+def reset_graphql_session():
+    """Reset the global gql session between tests."""
+    graphql_module._runtime_state["client"] = None
+    graphql_module._runtime_state["session"] = None
+    yield
+    graphql_module._runtime_state["client"] = None
+    graphql_module._runtime_state["session"] = None
 
 
 class TestBatchQueryOpenTargetsGraphQL:
@@ -17,12 +28,11 @@ class TestBatchQueryOpenTargetsGraphQL:
     @pytest.mark.asyncio
     async def test_batch_query_success(self, batch_query_string, batch_variables_with_key):
         """Test successful batch query execution."""
-        # Mock execute_graphql_query to return success for each call
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.side_effect = [
+            mock_execute.return_value = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510", "approvedSymbol": "TP53"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000012048", "approvedSymbol": "BRCA1"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618", "approvedSymbol": "BRCA2"}}),
@@ -64,10 +74,10 @@ class TestBatchQueryOpenTargetsGraphQL:
         ]
 
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.side_effect = [
+            mock_execute.return_value = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
             ]
@@ -93,10 +103,10 @@ class TestBatchQueryOpenTargetsGraphQL:
     async def test_batch_query_partial_failures(self, batch_query_string, batch_variables_with_key):
         """Test batch query with some queries failing."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.side_effect = [
+            mock_execute.return_value = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_error("Query failed"),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
@@ -118,15 +128,65 @@ class TestBatchQueryOpenTargetsGraphQL:
         assert result_dict["ENSG00000012048"].result.status == QueryResultStatus.ERROR
 
     @pytest.mark.asyncio
+    async def test_batch_query_results_mapped_to_correct_keys(
+        self,
+        batch_query_string,
+        batch_variables_with_key,
+    ):
+        """Each result must be mapped to the key from its own variables entry,
+        including correct data for successes and error details for failures.
+        """
+        with patch(
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            new_callable=AsyncMock,
+        ) as mock_execute:
+            mock_execute.return_value = [
+                QueryResult.create_success({"target": {"id": "ENSG00000141510", "approvedSymbol": "TP53"}}),
+                QueryResult.create_error("Upstream error for BRCA1"),
+                QueryResult.create_success({"target": {"id": "ENSG00000139618", "approvedSymbol": "BRCA2"}}),
+            ]
+
+            result = await batch_query_fn(
+                query_string=batch_query_string,
+                variables_list=batch_variables_with_key,
+                key_field="ensemblId",
+            )
+
+        assert isinstance(result, BatchQueryResult)
+        result_dict = {r.key: r for r in result.results}
+
+        # Correct data for first entry
+        tp53 = result_dict["ENSG00000141510"]
+        assert tp53.result.status == QueryResultStatus.SUCCESS
+        assert tp53.result.result["target"]["approvedSymbol"] == "TP53"
+
+        # Error mapped to middle entry, not bleed into neighbours
+        brca1 = result_dict["ENSG00000012048"]
+        assert brca1.result.status == QueryResultStatus.ERROR
+        assert "BRCA1" in str(brca1.result.message)
+
+        # Correct data for last entry despite middle failure
+        brca2 = result_dict["ENSG00000139618"]
+        assert brca2.result.status == QueryResultStatus.SUCCESS
+        assert brca2.result.result["target"]["approvedSymbol"] == "BRCA2"
+
+        # Order in result list matches original input order
+        assert [r.key for r in result.results] == [
+            "ENSG00000141510",
+            "ENSG00000012048",
+            "ENSG00000139618",
+        ]
+
+    @pytest.mark.asyncio
     async def test_batch_query_with_jq_filter(self, batch_query_string, batch_variables_with_key):
         """Test batch query with jq filter applied."""
         jq_filter = ".data.target.approvedSymbol"
 
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.side_effect = [
+            mock_execute.return_value = [
                 QueryResult.create_success("TP53"),
                 QueryResult.create_success("BRCA1"),
                 QueryResult.create_success("BRCA2"),
@@ -139,11 +199,12 @@ class TestBatchQueryOpenTargetsGraphQL:
                 jq_filter=jq_filter,
             )
 
-        # Verify jq_filter was passed to execute_graphql_query
-        assert mock_execute.call_count == 3
-        for call in mock_execute.call_args_list:
-            # jq_filter is passed as a keyword argument
-            assert call.kwargs["jq_filter"] == jq_filter
+        # Verify jq_filter was passed to execute_graphql_batch_query
+        mock_execute.assert_called_once_with(
+            batch_query_string,
+            batch_variables_with_key,
+            jq_filter,
+        )
 
         assert isinstance(result, BatchQueryResult)
         assert result.summary.successful == 3
@@ -152,10 +213,10 @@ class TestBatchQueryOpenTargetsGraphQL:
     async def test_batch_query_without_jq_filter(self, batch_query_string, batch_variables_with_key):
         """Test batch query without jq filter."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.side_effect = [
+            mock_execute.return_value = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000012048"}}),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
@@ -168,23 +229,24 @@ class TestBatchQueryOpenTargetsGraphQL:
                 jq_filter=None,
             )
 
-        # Verify jq_filter was NOT passed (should be None)
-        assert mock_execute.call_count == 3
-        for call in mock_execute.call_args_list:
-            # jq_filter is passed as a keyword argument
-            assert call.kwargs.get("jq_filter") is None
+        # Verify jq_filter was passed as None
+        mock_execute.assert_called_once_with(
+            batch_query_string,
+            batch_variables_with_key,
+            None,
+        )
 
         assert isinstance(result, BatchQueryResult)
         assert result.summary.successful == 3
 
     @pytest.mark.asyncio
     async def test_batch_query_exception_handling(self, batch_query_string, batch_variables_with_key):
-        """Test that error results during individual query execution are handled."""
+        """Test that error results during batch query execution are handled."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.side_effect = [
+            mock_execute.return_value = [
                 QueryResult.create_success({"target": {"id": "ENSG00000141510"}}),
                 QueryResult.create_error("Network error"),
                 QueryResult.create_success({"target": {"id": "ENSG00000139618"}}),
@@ -209,12 +271,12 @@ class TestBatchQueryOpenTargetsGraphQL:
 
     @pytest.mark.asyncio
     async def test_batch_query_calls_execute_correctly(self, batch_query_string, batch_variables_with_key):
-        """Test that batch query calls execute_graphql_query correctly."""
+        """Test that batch query calls execute_graphql_batch_query correctly."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = QueryResult.create_success({})
+            mock_execute.return_value = [QueryResult.create_success({})]
 
             await batch_query_fn(
                 query_string=batch_query_string,
@@ -225,41 +287,45 @@ class TestBatchQueryOpenTargetsGraphQL:
             # Verify the function was called with correct arguments
             mock_execute.assert_called_once_with(
                 batch_query_string,
-                batch_variables_with_key[0],
-                jq_filter=None,
+                [batch_variables_with_key[0]],
+                None,
             )
 
     @pytest.mark.asyncio
     async def test_batch_query_parallel_execution(self, batch_query_string, batch_variables_with_key):
-        """Test that queries are executed in parallel."""
-        call_order = []
-
-        async def track_call(query_string, variables, jq_filter=None):
-            call_order.append(variables["ensemblId"])
-            return QueryResult.create_success({})
-
+        """Test that all variables are passed in a single batch call."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
-            side_effect=track_call,
-        ):
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
+            new_callable=AsyncMock,
+        ) as mock_execute:
+            mock_execute.return_value = [
+                QueryResult.create_success({}),
+                QueryResult.create_success({}),
+                QueryResult.create_success({}),
+            ]
+
             await batch_query_fn(
                 query_string=batch_query_string,
                 variables_list=batch_variables_with_key,
                 key_field="ensemblId",
             )
 
-        # Verify all queries were called (order may vary due to parallel execution)
-        assert len(call_order) == 3
-        assert set(call_order) == {"ENSG00000141510", "ENSG00000012048", "ENSG00000139618"}
+        # Verify all variables were passed in a single call
+        mock_execute.assert_called_once()
+        assert mock_execute.call_args.args[1] == batch_variables_with_key
 
     @pytest.mark.asyncio
     async def test_batch_query_result_structure(self, batch_query_string, batch_variables_with_key):
         """Test the structure of batch query results."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = QueryResult.create_success({"target": {"id": "test"}})
+            mock_execute.return_value = [
+                QueryResult.create_success({"target": {"id": "test"}}),
+                QueryResult.create_success({"target": {"id": "test"}}),
+                QueryResult.create_success({"target": {"id": "test"}}),
+            ]
 
             result = await batch_query_fn(
                 query_string=batch_query_string,
@@ -282,13 +348,15 @@ class TestBatchQueryOpenTargetsGraphQL:
     async def test_batch_query_jq_filter_warning(self, batch_query_string, batch_variables_with_key):
         """Test that jq filter warnings are preserved in results."""
         with patch(
-            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_query",
+            "open_targets_platform_mcp.tools.batch_query.batch_query.execute_graphql_batch_query",
             new_callable=AsyncMock,
         ) as mock_execute:
-            mock_execute.return_value = QueryResult.create_warning(
-                {"target": {"id": "test"}},
-                "jq filter failed: null value",
-            )
+            mock_execute.return_value = [
+                QueryResult.create_warning(
+                    {"target": {"id": "test"}},
+                    "jq filter failed: null value",
+                ),
+            ]
 
             result = await batch_query_fn(
                 query_string=batch_query_string,
@@ -314,8 +382,10 @@ class TestBatchQueryIntegration:
     """Integration tests with real API calls."""
 
     @pytest.mark.asyncio
-    async def test_real_batch_query(self):
-        """Test real batch query against Open Targets Platform API."""
+    async def test_real_batch_query_raises_on_unsupported_api(self):
+        """The Open Targets Platform API does not support native batch queries."""
+        from gql.transport.exceptions import TransportConnectionFailed, TransportServerError
+
         query = """
         query GetTarget($ensemblId: String!) {
             target(ensemblId: $ensemblId) {
@@ -330,56 +400,5 @@ class TestBatchQueryIntegration:
             {"ensemblId": "ENSG00000012048"},
         ]
 
-        result = await batch_query_fn(query_string=query, variables_list=variables_list, key_field="ensemblId")
-
-        assert isinstance(result, BatchQueryResult)
-        assert result.summary.total == 2
-        assert result.summary.successful == 2
-        assert result.summary.failed == 0
-
-        # Verify actual data
-        result_dict = {r.key: r for r in result.results if r.key is not None}
-        assert result_dict["ENSG00000141510"].result.result["target"]["approvedSymbol"] == "TP53"
-        assert result_dict["ENSG00000012048"].result.result["target"]["approvedSymbol"] == "BRCA1"
-
-    @pytest.mark.asyncio
-    async def test_real_batch_query_with_jq_filter(self):
-        """Test real batch query with jq filter (requires jq enabled)."""
-        from open_targets_platform_mcp.settings import settings
-
-        # Enable jq for this integration test
-        original_jq_enabled = settings.jq_enabled
-        settings.jq_enabled = True
-
-        try:
-            query = """
-            query GetTarget($ensemblId: String!) {
-                target(ensemblId: $ensemblId) {
-                    id
-                    approvedSymbol
-                }
-            }
-            """
-
-            variables_list = [
-                {"ensemblId": "ENSG00000141510"},
-                {"ensemblId": "ENSG00000012048"},
-            ]
-
-            result = await batch_query_fn(
-                query_string=query,
-                variables_list=variables_list,
-                key_field="ensemblId",
-                jq_filter=".target.approvedSymbol",
-            )
-
-            assert isinstance(result, BatchQueryResult)
-            result_dict = {r.key: r for r in result.results if r.key is not None}
-            # jq filter returns a list (even for single results)
-            assert isinstance(result_dict["ENSG00000141510"].result.result, list)
-            assert result_dict["ENSG00000141510"].result.result == ["TP53"]
-            assert isinstance(result_dict["ENSG00000012048"].result.result, list)
-            assert result_dict["ENSG00000012048"].result.result == ["BRCA1"]
-        finally:
-            # Restore original value
-            settings.jq_enabled = original_jq_enabled
+        with pytest.raises((TransportServerError, TransportConnectionFailed, Exception)):
+            await batch_query_fn(query_string=query, variables_list=variables_list, key_field="ensemblId")

--- a/test/test_tools/test_query.py
+++ b/test/test_tools/test_query.py
@@ -16,11 +16,11 @@ query_fn = _query_impl
 @pytest.fixture(autouse=True)
 def reset_graphql_session():
     """Reset the global gql session between tests."""
-    graphql_module._runtime_state["client"] = None
-    graphql_module._runtime_state["session"] = None
+    graphql_module._runtime_state.client = None
+    graphql_module._runtime_state.session = None
     yield
-    graphql_module._runtime_state["client"] = None
-    graphql_module._runtime_state["session"] = None
+    graphql_module._runtime_state.client = None
+    graphql_module._runtime_state.session = None
 
 
 class TestQueryOpenTargetsGraphQL:

--- a/test/test_tools/test_query.py
+++ b/test/test_tools/test_query.py
@@ -4,12 +4,23 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from open_targets_platform_mcp.client import graphql as graphql_module
 from open_targets_platform_mcp.model.result import QueryResult, QueryResultStatus
 from open_targets_platform_mcp.settings import settings
 from open_targets_platform_mcp.tools.query.query import _query_impl
 
 # Use the internal implementation function directly for testing
 query_fn = _query_impl
+
+
+@pytest.fixture(autouse=True)
+def reset_graphql_session():
+    """Reset the global gql session between tests."""
+    graphql_module._runtime_state["client"] = None
+    graphql_module._runtime_state["session"] = None
+    yield
+    graphql_module._runtime_state["client"] = None
+    graphql_module._runtime_state["session"] = None
 
 
 class TestQueryOpenTargetsGraphQL:


### PR DESCRIPTION
The PR introduces the following:
1. GraphQL client session is reused to reduce connections created for improved performance.
2. Handle query errors and include the error to the tool call result, which partially covers what https://github.com/opentargets/open-targets-platform-mcp/pull/32 does

To reviewers, two concerns you may have:
1. The error handling is catching the base Exception which in theory could be a security risk but at the moment I don't want to deep dive the possible errors that may happen. Given the code block https://github.com/opentargets/open-targets-platform-mcp/blob/feat-graphql-connection-pool/src/open_targets_platform_mcp/client/graphql.py#L80 , I doubt there will be any meaningful security risk but please be my guest.
2. The native `gql` batch query is not used because the official GraphQL API does not accept batch query so batch query is serialised like before.

Related issues:
1. https://github.com/opentargets/open-targets-platform-mcp/issues/24