### PR TITLE
Add User-Agent header for GraphQL requests

### DIFF
--- a/src/open_targets_platform_mcp/__init__.py
+++ b/src/open_targets_platform_mcp/__init__.py
@@ -1,5 +1,7 @@
 """Open Targets Platform MCP - Model Context Protocol server for Open Targets Platform API."""
 
+__dist_name__ = "open-targets-platform-mcp"
+
 from importlib.metadata import version
 
-__version__ = version("open_targets_platform_mcp")
+__version__ = version(__dist_name__)

--- a/src/open_targets_platform_mcp/cli.py
+++ b/src/open_targets_platform_mcp/cli.py
@@ -1,26 +1,23 @@
 import asyncio
-from importlib import metadata
 from typing import Annotated
 
 import typer
 from starlette.middleware import Middleware
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from open_targets_platform_mcp import __dist_name__, __version__
 from open_targets_platform_mcp.create_server import create_server
 from open_targets_platform_mcp.settings import TransportType, settings
 
-PACKAGE_NAME = "open_targets_platform_mcp"
-PACKAGE_VERSION = metadata.version(PACKAGE_NAME)
-
 app = typer.Typer(
-    help=f"Model Context Protocol server for Open Targets Platform version {PACKAGE_VERSION}",
+    help=f"Model Context Protocol server for Open Targets Platform version {__version__}",
 )
 
 
 def _version_callback(value: bool) -> None:
-    """Show the package version and exit."""
+    """Show the application version and exit."""
     if value:
-        typer.echo(f"{PACKAGE_NAME} {PACKAGE_VERSION}")
+        typer.echo(f"{__dist_name__} {__version__}")
         raise typer.Exit
 
 

--- a/src/open_targets_platform_mcp/client/graphql.py
+++ b/src/open_targets_platform_mcp/client/graphql.py
@@ -6,6 +6,7 @@ from gql.client import AsyncClientSession
 from gql.transport.aiohttp import AIOHTTPTransport
 from graphql import GraphQLSchema
 
+from open_targets_platform_mcp import __dist_name__, __version__
 from open_targets_platform_mcp.model.exception import JqCompilationError
 from open_targets_platform_mcp.model.query_result import QueryResult
 from open_targets_platform_mcp.settings import settings
@@ -20,10 +21,14 @@ _runtime_state: _RuntimeState = _RuntimeState()
 
 
 def _create_graphql_client(*, fetch_schema_from_transport: bool = False) -> Client:
+    user_agent = f"{__dist_name__}/{__version__}"
+    if settings.http_base_url:
+        user_agent += f" ({settings.http_base_url})"
     transport = AIOHTTPTransport(
         url=str(settings.api_endpoint),
         headers={
             "Content-Type": "application/json",
+            "User-Agent": user_agent,
         },
         timeout=settings.api_call_timeout,
     )

--- a/src/open_targets_platform_mcp/settings.py
+++ b/src/open_targets_platform_mcp/settings.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     transport: TransportType = TransportType.HTTP
     http_host: str = "localhost"
     http_port: int = 8000
+    http_base_url: HttpUrl | None = None
     stateless_http: bool = True
     rate_limiting_enabled: bool = False
     rate_limiting_max_requests_per_second: float = 3


### PR DESCRIPTION
This PR enables https://github.com/opentargets/open-targets-platform-mcp/issues/38

The value of the header is `{distribution name}/{version} ({http_base_url})`

`http_base_url` is optional and is set via `OTP_MCP_HTTP_BASE_URL` environment variable.