### PR TITLE
Remove handshake rate limiting

### DIFF
--- a/src/open_targets_platform_mcp/create_server.py
+++ b/src/open_targets_platform_mcp/create_server.py
@@ -6,13 +6,13 @@ from importlib import metadata, resources
 from typing import Any
 
 from fastmcp import FastMCP
-from fastmcp.server.middleware.rate_limiting import RateLimitingMiddleware
 from fastmcp.server.middleware.timing import DetailedTimingMiddleware
 from mcp.types import Icon
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 
 from open_targets_platform_mcp.helper import build_description
+from open_targets_platform_mcp.middleware.handshake_exempt_rate_limiting import HandshakeExemptRateLimitingMiddleware
 from open_targets_platform_mcp.settings import settings
 from open_targets_platform_mcp.tools import (
     batch_query_with_jq,
@@ -57,7 +57,7 @@ async def create_server() -> FastMCP:
 
     if settings.rate_limiting_enabled:
         mcp.add_middleware(
-            RateLimitingMiddleware(
+            HandshakeExemptRateLimitingMiddleware(
                 settings.rate_limiting_max_requests_per_second,
                 settings.rate_limiting_burst_capacity,
             ),

--- a/src/open_targets_platform_mcp/middleware/__init__.py
+++ b/src/open_targets_platform_mcp/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""Middleware for the Open Targets Platform MCP server."""

--- a/src/open_targets_platform_mcp/middleware/handshake_exempt_rate_limiting.py
+++ b/src/open_targets_platform_mcp/middleware/handshake_exempt_rate_limiting.py
@@ -1,0 +1,23 @@
+"""Rate limiting middleware with workarounds for FastMCP quirks."""
+
+from fastmcp.server.middleware.middleware import CallNext, MiddlewareContext
+from fastmcp.server.middleware.rate_limiting import RateLimitingMiddleware
+
+_EXEMPT_METHODS = frozenset({"initialize", "tools/list"})
+
+
+class HandshakeExemptRateLimitingMiddleware(RateLimitingMiddleware):
+    """RateLimitingMiddleware that exempts certain MCP handshake methods.
+
+    Workaround for a FastMCP bug where McpError raised during 'initialize'
+    middleware is caught by session.py's validation error handler and
+    incorrectly reported as INVALID_PARAMS to the client.
+
+    Exempting 'initialize' and 'tools/list' to always allow agent clients to
+    register the MCP server.
+    """
+
+    async def on_request(self, context: MiddlewareContext, call_next: CallNext) -> object:
+        if context.method in _EXEMPT_METHODS:
+            return await call_next(context)
+        return await super().on_request(context, call_next)


### PR DESCRIPTION
This PR serves two purposes:
1. Remove the issue https://github.com/opentargets/open-targets-platform-mcp/issues/20 which that `fastmcp` does not handle exceptions raised from handshake methods well.
2. Many agent clients do an one-off initialisation for listing tools when adding a MCP server. Failing at that stage may prevent the client from adding the server or exposing it to LLMs.